### PR TITLE
Fix raw code blocks in dark mode

### DIFF
--- a/docs/.vitepress/theme/styles/code.styl
+++ b/docs/.vitepress/theme/styles/code.styl
@@ -217,3 +217,7 @@ pre[class*='language-'] {
   border-radius: 6px;
   overflow: auto;
 }
+
+.dark .vp-raw {
+  background-color: #333;
+}


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

*Summarize the changes briefly, including which issue/ticket this resolves. If it closes an existing Github issue, include "Closes #[issue number]"*
An outside dev noticed that raw code blocks don't show up well in dark mode.

## What are the specific steps to test this change?

*For example:*
> 1. Run the website and log in as an admin
> 2. Open a piece manager modal and select several pieces
> 3. Click the "Archive" button on the top left of the manager and confirm that it should proceed
> 4. Check that all pieces have been archived properly

1. Start the docs with `npm run dev`
2. Navigate to `http://localhost:5173/tutorials/setting-up-the-advanced-permission-pro-extension.html#installing-the-advanced-permission-module'
3. Switch between dark and light mode to make sure the blocks below the "WARNING" are legible.
## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [ ] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
