### PR TITLE
navigation and landing page suggestions for new tutorials organization

### DIFF
--- a/docs/.vitepress/sidebarTutorials.js
+++ b/docs/.vitepress/sidebarTutorials.js
@@ -6,73 +6,25 @@ const sidebarTutorials = [
     customClass: 'reduce-bottom-margin'
   },
   {
-    text: 'Learn ApostropheCMS',
+    text: 'Intro to ApostropheCMS',
     collapsed: false,
+    link: 'tutorials/introduction.md',
     items: [
-      { text: 'Introduction', link: 'tutorials/introduction.md' },
-      { text: 'Code Organization', link: 'tutorials/code-organization.md' },
+      { text: 'Organizing Your Code', link: 'tutorials/code-organization.md' },
       { text: 'Creating Pages', link: 'tutorials/pages.md' },
-      { text: 'Add CSS and JS Assets', link: 'tutorials/assets.md' },
+      { text: 'Adding CSS and JS Assets', link: 'tutorials/assets.md' },
       { text: 'Creating Widgets', link: 'tutorials/widgets.md' },
       { text: 'Creating Pieces', link: 'tutorials/pieces.md' },
       { text: 'Building Navigation', link: 'tutorials/navigation.md' },
-      { text: 'Configuring Admin Bar', link: 'tutorials/admin-ui.md' },
+      { text: 'Configuring the Admin Bar', link: 'tutorials/admin-ui.md' },
       { text: 'Adding Extensions', link: 'tutorials/adding-extensions.md' }
     ]
   },
   {
-    text: 'Beyond the Basics',
+    text: 'ApostropheCMS & Astro',
     collapsed: false,
+    link: 'tutorials/astro/apostrophecms-and-astro.md',
     items: [
-      {
-        text: 'From HTML to ApostropheCMS',
-        link: 'tutorials/html-conversion.md'
-      },
-      {
-        text: 'Composing Custom Fields',
-        link: 'tutorials/reusing-standard-fields.md'
-      },
-      {
-        text: 'Navigation Building Techniques',
-        link: 'tutorials/building-navigation.md'
-      },
-      {
-        text: 'Creating Custom Rich Text Extensions',
-        collapsed: false,
-        link: 'tutorials/introduction-to-rich-text-extensions.md',
-        items: [
-          {
-            text: 'Using Tiptap Extensions',
-            link: 'tutorials/using-tiptap-extensions.md'
-          },
-          {
-            text: 'Creating a Text Replacement Extension',
-            link: 'tutorials/creating-a-text-replacement-extension.md'
-          },
-          {
-            text: 'Toolbar and Insert Menu Extensions',
-            link: 'tutorials/rich-text-extension-deep-dive.md'
-          }
-        ]
-      },
-      {
-        text: 'Harnessing Dynamic Routing in ApostropheCMS',
-        link: 'tutorials/dynamic-routing.md'
-      },
-      {
-        text: 'Using JSX to Build a Weather Widget in ApostropheCMS',
-        link: 'tutorials/using-jsx-in-apostrophe.md'
-      }
-    ]
-  },
-  {
-    text: 'Astro Topics',
-    collapsed: false,
-    items: [
-      {
-        text: 'ApostropheCMS + Astro',
-        link: 'tutorials/astro/apostrophecms-and-astro.md'
-      },
       {
         text: 'Introducing Apollo',
         link: 'tutorials/astro/introducing-apollo.md'
@@ -90,17 +42,64 @@ const sidebarTutorials = [
         link: 'tutorials/astro/creating-pieces.md'
       },
       {
-        text: 'Deploying an ApostropheCMS-Astro project',
+        text: 'Deploying With Astro',
         link: 'tutorials/astro/deploying-hybrid-projects.md'
       }
     ]
   },
   {
-    text: 'Pro topics',
+    text: 'Recipes',
     collapsed: false,
+    link: 'tutorials/recipes.md',
     items: [
       {
-        text: 'Setting up Advanced Permissions',
+        text: 'Converting a Static Template',
+        link: 'tutorials/html-conversion.md'
+      },
+      {
+        text: 'Composing Custom Fields',
+        link: 'tutorials/reusing-standard-fields.md'
+      },
+      {
+        text: 'Building Navigation',
+        link: 'tutorials/building-navigation.md'
+      },
+      {
+        text: 'Customizing Rich Text',
+        collapsed: false,
+        link: 'tutorials/introduction-to-rich-text-extensions.md',
+        items: [
+          {
+            text: 'Installing Extensions',
+            link: 'tutorials/using-tiptap-extensions.md'
+          },
+          {
+            text: 'Creating an Extension',
+            link: 'tutorials/creating-a-text-replacement-extension.md'
+          },
+          {
+            text: 'Extending the Toolbar',
+            link: 'tutorials/rich-text-extension-deep-dive.md'
+          }
+        ]
+      },
+      {
+        text: 'Harnessing Dynamic Routing',
+        link: 'tutorials/dynamic-routing.md'
+      },
+      {
+        text: 'Building a JSX Widget',
+        link: 'tutorials/using-jsx-in-apostrophe.md'
+      }
+    ]
+  },
+  {
+    text: 'Pro Topics',
+    collapsed: false,
+    link: 'tutorials/pro.md',
+    items: [
+      {
+        text: 'Using Advanced Permissions',
         link: 'tutorials/setting-up-the-advanced-permission-pro-extension.md'
       }
     ]

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -38,4 +38,39 @@ exampleTutorials:
 
 Step-by-step tutorials that go beyond the technical explanations in our Guide or Reference sections. Explore real-world implementations, from full project builds to focused how-tos, designed to help you get hands-on with ApostropheCMS.
 
-<AposTutorialFilter />
+<AposTwoColumns>
+  <template #leftColumn>
+    <AposCtaButton
+    detail-heading="Series"
+    title="Intro to ApostropheCMS"
+    content="Dive into ApostropheCMS with a hands-on tutorial series. We'll guide you step-by-step through crafting your first website, exploring fundamental concepts and practical implementations."
+    url="/tutorials/introduction.html"
+    />
+  </template>
+  <template #rightColumn>
+    <AposCtaButton
+      detail-heading="Series"
+      title="ApostropheCMS & Astro"
+      content="ApostropheCMS and Astro work seamlessly together through the `apostrophe-astro` extension. Learn who this integration is for and what makes it a powerful choice for building modern websites."
+      url="/tutorials/astro/introducing-apollo.html"
+    />
+  </template>
+</AposTwoColumns>
+<AposTwoColumns>
+  <template #leftColumn>
+    <AposCtaButton
+      detail-heading="Collection"
+      title="Recipes"
+      content="Practical, standalone tutorials for solving specific challenges in ApostropheCMS. These recipes range from simple tips to advanced patterns and can be filtered by topic to match your needs."
+      url="/tutorials/recipes.html"
+    />
+  </template>
+  <template #rightColumn>
+    <AposCtaButton
+      detail-heading="Collection"
+      title="Pro Topics"
+      content="In-depth tutorials for teams using ApostropheCMS’s commercial modules and advanced capabilities. These guides support complex implementations, from multisite setups to enterprise-grade integrations and workflows."
+      url="/tutorials/pro.html"
+    />
+  </template>
+</AposTwoColumns>

--- a/docs/tutorials/pro.md
+++ b/docs/tutorials/pro.md
@@ -7,3 +7,14 @@ excludeFromFilters: true
 # Pro Topics
 
 In-depth tutorials for teams using ApostropheCMS’s commercial modules and advanced capabilities. These guides support complex implementations, from multisite setups to enterprise-grade integrations and workflows.
+
+<AposTwoColumns>
+  <template #leftColumn>
+    <AposCtaButton
+    detail-heading="Series"
+    title="Using Advanced Permissions"
+    content="The Advanced Permission module is a Pro extension that adds more granular control over content permissions. It provides the ability to create custom groups and assign them to users directly in the admin UI."
+    url="/tutorials/setting-up-the-advanced-permission-pro-extension.html"
+    />
+  </template>
+</AposTwoColumns>

--- a/docs/tutorials/pro.md
+++ b/docs/tutorials/pro.md
@@ -1,0 +1,9 @@
+---
+next: false
+prev: false
+excludeFromFilters: true
+---
+
+# Pro Topics
+
+In-depth tutorials for teams using ApostropheCMS’s commercial modules and advanced capabilities. These guides support complex implementations, from multisite setups to enterprise-grade integrations and workflows.

--- a/docs/tutorials/recipes.md
+++ b/docs/tutorials/recipes.md
@@ -34,8 +34,8 @@ exampleTutorials:
         type: "pro"
         effort: "advanced"
 ---
-# Tutorials
+# Recipes
 
-Step-by-step tutorials that go beyond the technical explanations in our Guide or Reference sections. Explore real-world implementations, from full project builds to focused how-tos, designed to help you get hands-on with ApostropheCMS.
+Practical, standalone tutorials for solving specific challenges in ApostropheCMS. These recipes range from simple tips to advanced patterns and can be filtered by topic to match your needs.
 
 <AposTutorialFilter />


### PR DESCRIPTION
suggestions for how the side navigation can be cleaned up and overall clarity of the tutorials section can be improved with some refinements to landing page content.

- tutorials home page is a collection of four big links to the sections outlined in the sidebar
- the two big tutorial "series" (intro and astro) come first are presented to be experienced sequentially
- the recipes landing page contains the filterable experience to account for the large and growing amount of tutorials in there
- pro topics is cleaned up a bit and can evolve to grow with more tutorials or could be merged into the larger recipes section with an appropriate filter

additional notes:

- fixed an issue with the astro pages not properly highlighting because of inconsistent capitalization between URLs and folder names
- need somebody else to tackle how the recipes filter component would just show items inside the recipes section
- it would be nice if we can not trigger the collapse behavior on the sidebar if the link you're clicking has a url that you're being taken to
- eventually we can consider adding in some additional style to the tutorial series in the sidebar
